### PR TITLE
Specify TLSv1_2 to Savon client because Bronto is

### DIFF
--- a/lib/bronto/base.rb
+++ b/lib/bronto/base.rb
@@ -50,7 +50,7 @@ module Bronto
     def self.api(api_key, refresh = false)
       return connection_cache[api_key][:client] unless refresh || session_expired(api_key) || connection_cache[api_key].nil?
 
-      client = Savon.client(wsdl: 'https://api.bronto.com/v4?wsdl', ssl_version: :TLSv1)
+      client = Savon.client(wsdl: 'https://api.bronto.com/v4?wsdl', ssl_version: :TLSv1_2)
       resp = client.call(:login, message: { api_token: api_key })
 
       connection_cache[api_key] = {


### PR DESCRIPTION
dropping support for TLS 1 and 1.1.