### PR TITLE
De 2151 bronto contact update fix

### DIFF
--- a/lib/bronto/contact.rb
+++ b/lib/bronto/contact.rb
@@ -40,7 +40,7 @@ module Bronto
     def change_status(status)
       api_key = self.api_key
       
-      resp = request(:update, {plural_class_name => [{:id => self.id, :status => status}]})
+      resp = request(:update, {self.class.plural_class_name => [{:id => self.id, :status => status}]})
 
       self.errors.clear
       results = resp[:return][:results]

--- a/lib/bronto/contact.rb
+++ b/lib/bronto/contact.rb
@@ -43,7 +43,8 @@ module Bronto
       resp = request(:update, {self.class.plural_class_name => [{:id => self.id, :status => status}]})
 
       self.errors.clear
-      result = resp[:return][:results].first
+      result = resp[:return][:results]
+      p result
       self.errors.add(result[:error_code], result[:error_string]) if result[:is_error]
       return self
     end

--- a/lib/bronto/contact.rb
+++ b/lib/bronto/contact.rb
@@ -45,7 +45,7 @@ module Bronto
       self.errors.clear
       result = resp[:return][:results]
       self.errors.add(result[:error_code], result[:error_string]) if result[:is_error]
-      return self
+      self
     end
 
     def initialize(options = {})

--- a/lib/bronto/contact.rb
+++ b/lib/bronto/contact.rb
@@ -89,9 +89,9 @@ module Bronto
 
     def to_hash
       if id.present?
-        { id: id, email: email, fields: fields.values.map(&:to_hash) }
+        { id: id, email: email, status: status, fields: fields.values.map(&:to_hash) }
       else
-        { email: email, fields: fields.values.map(&:to_hash) }
+        { email: email, status: status, fields: fields.values.map(&:to_hash) }
       end
     end
 

--- a/lib/bronto/contact.rb
+++ b/lib/bronto/contact.rb
@@ -18,11 +18,11 @@ module Bronto
       Array.wrap(resp[:return]).map { |hash| new(hash) }
     end
 
-    def self.save(*objs)
+    def self.save(*objs, force_udpate = false)
       objs = objs.flatten
       api_key = objs.first.is_a?(String) ? objs.shift : self.api_key
-
-      resp = request(:add_or_update, {plural_class_name => objs.map(&:to_hash)})
+      operation = force_update ? :update : :add_or_update
+      resp = request(operation, {plural_class_name => objs.map(&:to_hash)})
 
       objs.each { |o| o.errors.clear }
 
@@ -35,6 +35,10 @@ module Bronto
       end
 
       objs
+    end
+    
+    def self.update(*objs)
+      save(objs, true)
     end
 
     def initialize(options = {})
@@ -62,6 +66,10 @@ module Bronto
 
     def save
       self.class.save(self)
+    end
+    
+    def update
+      self.class.update(self)
     end
 
     def to_hash

--- a/lib/bronto/contact.rb
+++ b/lib/bronto/contact.rb
@@ -44,7 +44,6 @@ module Bronto
 
       self.errors.clear
       result = resp[:return][:results]
-      p result
       self.errors.add(result[:error_code], result[:error_string]) if result[:is_error]
       return self
     end

--- a/lib/bronto/contact.rb
+++ b/lib/bronto/contact.rb
@@ -43,7 +43,7 @@ module Bronto
       resp = request(:update, {self.class.plural_class_name => [{:id => self.id, :status => status}]})
 
       self.errors.clear
-      results = resp[:return][:results]
+      result = resp[:return][:results].first
       self.errors.add(result[:error_code], result[:error_string]) if result[:is_error]
       return self
     end


### PR DESCRIPTION
Adds a new method `change_status` which can be called on a contact and ACTUALLY updates the status.  This was needed because the `add_or_update` endpoint will NOT update the status as described here: http://dev.bronto.com/api/soap/functions/update/addorupdatecontacts-2/

This method will be called in Spoonclassic once this PR is merged into master:
https://github.com/Spoonflower/spoonflower/pull/1770